### PR TITLE
Upstream: is the version restriction (< 2.3) on network needed ?

### DIFF
--- a/hslogger.cabal
+++ b/hslogger.cabal
@@ -42,7 +42,7 @@ Library
         System.Log.Handler.Growl, System.Log.Handler.Log4jXML,
         System.Log.Logger
     Extensions: CPP, ExistentialQuantification
-    Build-Depends: network < 2.3, mtl
+    Build-Depends: network, mtl
     if !os(windows)
         Build-Depends: unix
     if flag(small_base)


### PR DESCRIPTION
Hello,

I have just faced a dependency conflict between a recent cabal package (requiring network >= 2.3) and hslogger (requiring network < 2.3 since the last release)

It seems that hslogger builds fine with network 2.3, but the restriction has been added very recentely:
https://github.com/jgoerzen/hslogger/commit/d80c4b94d93f89d92dfc81c22ffdec03a0c4bbea

What are your thoughts about this issue ?

Many thanks for your library and best regards, 
