### PR TITLE
fixed catching of SomeException in streamHandler

### DIFF
--- a/src/System/Log/Handler/Simple.hs
+++ b/src/System/Log/Handler/Simple.hs
@@ -18,7 +18,7 @@ module System.Log.Handler.Simple(streamHandler, fileHandler,
     where
 
 import Prelude hiding (catch)
-import Control.Exception (SomeException, catch)
+import Control.Exception (catch)
 import Data.Char (ord)
 
 import System.Log
@@ -64,7 +64,7 @@ streamHandler h pri =
     where
       writeToHandle hdl msg =
           hPutStrLn hdl msg `catch` (handleWriteException hdl msg)
-      handleWriteException :: Handle -> String -> SomeException -> IO ()
+      handleWriteException :: Handle -> String -> IOError -> IO ()
       handleWriteException hdl msg e =
           let msg' = "Error writing log message: " ++ show e ++
                      " (original message: " ++ msg ++ ")"


### PR DESCRIPTION
Hi,

Test code:

```
import Control.Concurrent
import Control.Monad
import System.Log.Logger

main = do
  updateGlobalLogger rootLoggerName (setLevel DEBUG)
  mainThread <- myThreadId
  _ <- forkIO $ forever $ do
    killThread mainThread
    threadDelay 1
  forever $ logM "" INFO "foobar"
```

Running this after compilation like this, shows that killing a thread that is in a logging function right now is not stable:

```
ghc --make test && ./test 2>&1 | uniq -c

   1 Error writing log message: thread killed (original message: foobar)
1116 foobar
   1 fooError writing log message: thread killed (original message: foobar)
2569 foobar
   1 Error writing log message: thread killed (original message: foobar)
1717 foobar
   1 fError writing log message: thread killed (original message: foobar)
3515 foobar
   1 foobarError writing log message: thread killed (original message: foobar)
3438 foobar
   1 foError writing log message: thread killed (original message: foobar)
3400 foobar
   1 test: thread killed
```

This is because streamHandler catches all the exceptions, even async ones.  This is totally discouraged and results in errors like this.

After my patch:

```
$ ghc -fforce-recomp --make test && ./test 2>&1 | uniq -c
[1 of 1] Compiling Main             ( test.hs, test.o )
Linking test ...
      1 test: thread killed
```

Please consider including this patch, thanks!

Further info: http://hackage.haskell.org/packages/archive/base/latest/doc/html/Control-Exception.html#g:4
