### PR TITLE
Bump upper bound on network package

### DIFF
--- a/hslogger.cabal
+++ b/hslogger.cabal
@@ -42,7 +42,7 @@ Library
         System.Log.Handler.Growl, System.Log.Handler.Log4jXML,
         System.Log.Logger
     Extensions: CPP, ExistentialQuantification
-    Build-Depends: network < 2.5, mtl
+    Build-Depends: network < 2.6, mtl
     if !os(windows)
         Build-Depends: unix
     if flag(small_base)


### PR DESCRIPTION
Hi,

The change from network-2.4.2.3 to network-2.5.0.0 is just the addition of CustomSockOpt to the SocketOption type, which doesn't seem to affect hslogger. Could the upper bound on the network package be bumped to 2.6 please?

Thanks,

David
