### PR TITLE
Fix haddock formatting

### DIFF
--- a/src/System/Log/Logger.hs
+++ b/src/System/Log/Logger.hs
@@ -472,7 +472,7 @@ updateGlobalLogger ln func =
     do l <- getLogger ln
        saveGlobalLogger (func l)
 
--- | Allow gracefull shutdown. Release all opened files/handlers/etc.
+-- | Allow gracefull shutdown. Release all opened files\/handlers\/etc.
 removeAllHandlers :: IO ()
 removeAllHandlers =
     modifyMVar_ logTree $ \lt -> do


### PR DESCRIPTION
The word `handlers` was in italics, which wasn't intended.
