### PR TITLE
use bytestring for multithreaded stderr output

### DIFF
--- a/hslogger.cabal
+++ b/hslogger.cabal
@@ -49,8 +49,8 @@ Library
     if !os(windows)
         Build-Depends: unix
     if flag(small_base)
-        build-depends: base >= 4 && < 5, containers, directory, process,
-                       time, old-locale
+        build-depends: base >= 4 && < 5, bytestring, containers, directory,
+                       process, time, old-locale
     else
         build-depends: base < 3, time
     -- GHC-Options: -O2

--- a/src/System/Log/Handler/Syslog.hs
+++ b/src/System/Log/Handler/Syslog.hs
@@ -44,6 +44,7 @@ module System.Log.Handler.Syslog(
                                        ) where
 
 import qualified Control.Exception as E
+import qualified Data.ByteString.Char8 as BC
 import System.Log
 import System.Log.Formatter
 import System.Log.Handler
@@ -249,7 +250,7 @@ instance LogHandler SyslogHandler where
     setFormatter sh f = sh{formatter = f}
     getFormatter sh = formatter sh
     emit sh (prio, msg) _ = do
-      when (elem PERROR (options sh)) (hPutStrLn stderr msg)
+      when (elem PERROR (options sh)) (BC.hPutStrLn stderr $ BC.pack msg)
       pidPart <- getPidPart
       void $ sendstr (toSyslogFormat msg pidPart)
       where


### PR DESCRIPTION
Logging on Syslog in multi-thread works fine, but if the `PERROR` option is active the output on stderr may be scrambled.