### PR TITLE
Simple handler: evaluate message before taking lock

### DIFF
--- a/hslogger.cabal
+++ b/hslogger.cabal
@@ -67,6 +67,7 @@ library
         base       >= 4.3 && < 4.13
       , bytestring >= 0.9 && < 0.11
       , containers >= 0.4 && < 0.7
+      , deepseq
       , time       >= 1.2 && < 1.10
       , old-locale >= 1.0 && < 1.1
 

--- a/src/System/Log/Handler/Simple.hs
+++ b/src/System/Log/Handler/Simple.hs
@@ -16,6 +16,7 @@ module System.Log.Handler.Simple(streamHandler, fileHandler,
     where
 
 import Control.Exception (tryJust)
+import Control.DeepSeq
 import Data.Char (ord)
 
 import System.Log
@@ -51,6 +52,7 @@ streamHandler :: Handle -> Priority -> IO (GenericHandler Handle)
 streamHandler h pri =
     do lock <- newMVar ()
        let mywritefunc hdl msg =
+               msg `deepseq`
                withMVar lock (\_ -> do writeToHandle hdl msg
                                        hFlush hdl
                              )


### PR DESCRIPTION
Because of laziness, the `msg` string in `streamHandler` can contain
arbitrary computations. In the previous state of affairs, the handler
would first take the lock then `putStrLn` the message. So all
the (pure) computation would happen in the critical section, and it
couldn't guarantee timely release of the lock.

Calling `deepseq` before the lock is taken makes sure that the locked
section does only what it must do: print the string.