### PR TITLE
Increase upper limit of base dependency version to support GHC 8.10

### DIFF
--- a/hslogger.cabal
+++ b/hslogger.cabal
@@ -64,7 +64,7 @@ library
     other-extensions: CPP ExistentialQuantification DeriveDataTypeable
 
     build-depends:
-        base       >= 4.3 && < 4.14
+        base       >= 4.3 && < 4.15
       , bytestring >= 0.9 && < 0.11
       , containers >= 0.4 && < 0.7
       , deepseq    >= 1.1 && < 1.5


### PR DESCRIPTION
I noticed you pushed a revision with this change to Hackage, but don't see it in this repository, hence the PR.