### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/hslogger.cabal
+++ b/hslogger.cabal
@@ -65,7 +65,7 @@ library
 
     build-depends:
         base       >= 4.3 && < 4.14
-      , bytestring >= 0.9 && < 0.11
+      , bytestring >= 0.9 && < 0.12
       , containers >= 0.4 && < 0.7
       , deepseq    >= 1.1 && < 1.5
       , time       >= 1.2 && < 1.10


### PR DESCRIPTION
Tested using
```cabal
packages: .
tests: True

constraints:
  bytestring >= 0.11

allow-newer:
  network:bytestring
```