### PR TITLE
bump base and bytestring upper bounds

### DIFF
--- a/hslogger.cabal
+++ b/hslogger.cabal
@@ -64,8 +64,8 @@ library
     other-extensions: CPP ExistentialQuantification DeriveDataTypeable
 
     build-depends:
-        base       >= 4.3 && < 4.14
-      , bytestring >= 0.9 && < 0.11
+        base       >= 4.3 && < 4.18
+      , bytestring >= 0.9 && < 0.12
       , containers >= 0.4 && < 0.7
       , deepseq    >= 1.1 && < 1.5
       , time       >= 1.2 && < 1.10


### PR DESCRIPTION
This builds with

```
cabal build -w ghc-9.4.1 --allow-newer=hsc2hs:base
```