### PR TITLE
Bump base to allow GHC 9.6 and up

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,20 +8,20 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220808
+# version: 0.15.20230312
 #
-# REGENDATA ("0.15.20220808",["github","hslogger.cabal"])
+# REGENDATA ("0.15.20230312",["github","hslogger.cabal"])
 #
 name: Haskell-CI
 on:
   push:
     branches:
       - master
-      - ci*
+      - ci-*
   pull_request:
     branches:
       - master
-      - ci*
+      - ci-*
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -34,14 +34,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.1
+          - compiler: ghc-9.6.1
             compilerKind: ghc
-            compilerVersion: 9.4.1
+            compilerVersion: 9.6.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.4
+          - compiler: ghc-9.4.4
             compilerKind: ghc
-            compilerVersion: 9.2.4
+            compilerVersion: 9.4.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.7
+            compilerKind: ghc
+            compilerVersion: 9.2.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -120,7 +125,7 @@ jobs:
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
@@ -128,7 +133,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -146,13 +151,13 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
@@ -211,7 +216,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -246,8 +251,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -271,8 +276,14 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -1,0 +1,103 @@
+# Adapted from github.com:debug-ito/staversion/.github/workflows/haskell.yml
+
+name: Stack build
+
+on:
+  push:
+    branches:
+      - master
+      - ci-*
+  pull_request:
+    branches:
+      - master
+      - ci-*
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  stack:
+    name: ${{ matrix.os }} Stack ${{ matrix.plan.resolver }} / ${{ matrix.plan.ghc }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        plan:
+          - resolver: 'nightly'
+          - resolver: 'lts'
+          - ghc: '9.4.4'
+            resolver: 'nightly-2023-03-24'
+          - ghc: '9.2.7'
+            resolver: 'lts-20.15'
+          - ghc: '9.0.2'
+            resolver: 'lts-19.33'
+          - ghc: '8.10.7'
+            resolver: 'lts-18.28'
+          - ghc: '8.8.4'
+            resolver: 'lts-16.31'
+          - ghc: '8.6.5'
+            resolver: 'lts-14.27'
+          - ghc: '8.4.4'
+            resolver: 'lts-12.26'
+          - ghc: '8.2.2'
+            resolver: 'lts-11.22'
+          # Older LTSs don't work with latest hslogger.
+
+        include:
+          - os: windows-latest
+            plan:
+              resolver: 'nightly'
+          - os: windows-latest
+            plan:
+              resolver: 'lts'
+
+          - os: macos-latest
+            plan:
+              resolver: 'nightly'
+          - os: macos-latest
+            plan:
+              resolver: 'lts'
+
+    runs-on: ${{ matrix.os }}
+    env:
+      STACK: stack --no-terminal --resolver ${{ matrix.plan.resolver }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure
+      run: $STACK init
+
+    - name: Install GHC via stack
+      run: $STACK ghc -- --version
+
+    - name: Haskell versions
+      run: |
+        STACK_VERSION=$(${STACK} --numeric-version)
+        echo "STACK_VERSION=${STACK_VERSION}" >> "${GITHUB_ENV}"
+        GHC_VERSION=$(${STACK} ghc -- --numeric-version)
+        echo "GHC_VERSION=${GHC_VERSION}" >> "${GITHUB_ENV}"
+
+      ## This causes troubles on Windows (spaces in env variable)?
+      # STACK_ROOT=$(${STACK} path --stack-root)
+      # echo "STACK_ROOT=${STACK_ROOT}" >> "${GITHUB_ENV}"
+
+    ## Caching ~/.stack without --system-ghc is probably not a good idea:
+    ## - too fat
+    ## - should be sensibly restored before installing GHC via stack,
+    ##   but then we don't know the GHC version; so at least 'lts' and 'nightly' would be brittle
+    ##
+    # - uses: actions/cache@v3
+    #   with:
+    #     path: ${{ env.STACK_ROOT }}
+    #     key: ${{ runner.os }}-stack-${{ env.STACK_VERSION }}-ghc-${{ env.GHC_VERSION }}-resolver-${{ matrix.plan.resolver }}
+
+    - name: Install dependencies
+      run: $STACK test --only-dependencies
+
+    - name: Build
+      run: $STACK build --haddock --no-haddock-deps
+
+    - name: Test
+      run: $STACK -j 1 test --haddock --no-haddock-deps

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 TAGS
 /.ghc.environment.*
 /cabal.project.local
+/.stack-work/

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,1 +1,1 @@
-branches: master ci*
+branches: master ci-*

--- a/hslogger.cabal
+++ b/hslogger.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 build-type: Simple
 name: hslogger
 version: 1.3.1.0
-x-revision: 6
+x-revision: 7
 
 maintainer: https://github.com/haskell-hvr/hslogger
 author: John Goerzen
@@ -36,8 +36,9 @@ extra-source-files:
     testsrc/runtests.hs
 
 tested-with:
-  GHC == 9.4.1
-  GHC == 9.2.4
+  GHC == 9.6.1
+  GHC == 9.4.4
+  GHC == 9.2.7
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4
@@ -79,7 +80,7 @@ library
     other-extensions: CPP ExistentialQuantification DeriveDataTypeable
 
     build-depends:
-        base       >= 4.3 && < 4.18
+        base       >= 4.3 && < 5
       , bytestring >= 0.9 && < 0.12
       , containers >= 0.4 && < 0.7
       , deepseq    >= 1.1 && < 1.5


### PR DESCRIPTION
Also add a stack CI for GHC 8.2 and up.

Published as revision 7: https://hackage.haskell.org/package/hslogger-1.3.1.0/revisions/