### PR TITLE
v1.3.1.1: Allow network-3.2 and time-1.14; bump CI to GHC 9.10

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.17.20231112
+# version: 0.19.20240403
 #
-# REGENDATA ("0.17.20231112",["github","hslogger.cabal"])
+# REGENDATA ("0.19.20240403",["github","hslogger.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,14 +32,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.1
+          - compiler: ghc-9.10.0.20240328
             compilerKind: ghc
-            compilerVersion: 9.8.1
+            compilerVersion: 9.10.0.20240328
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.3
+          - compiler: ghc-9.8.2
             compilerKind: ghc
-            compilerVersion: 9.6.3
+            compilerVersion: 9.8.2
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.6.4
+            compilerKind: ghc
+            compilerVersion: 9.6.4
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -96,8 +101,9 @@ jobs:
           mkdir -p "$HOME/.ghcup/bin"
           curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.3.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -115,12 +121,12 @@ jobs:
           echo "HC=$HC" >> "$GITHUB_ENV"
           echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
           echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.3.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -149,6 +155,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -199,9 +217,11 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package hslogger" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
-          allow-newer: bytestring
-          allow-newer: containers
+          allow-newer: network
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(hslogger)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -210,7 +230,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -242,22 +262,15 @@ jobs:
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local
-      - name: constraint set containers-0.7
+      - name: constraint set network-3.2
         run: |
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>= 0.7' all --dry-run ; fi
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then cabal-plan topo | sort ; fi
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>= 0.7' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>= 0.7' all ; fi
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>= 0.7' all ; fi
-      - name: constraint set bytestring-0.12
-        run: |
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>= 0.12' all --dry-run ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>= 0.12' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>= 0.12' all ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>= 0.12' all ; fi
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='network ^>= 3.2.0.0' all --dry-run
+          cabal-plan topo | sort
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='network ^>= 3.2.0.0' --dependencies-only -j2 all
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='network ^>= 3.2.0.0' all
+          $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='network ^>= 3.2.0.0' all
       - name: save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: always()
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 See also https://pvp.haskell.org/faq
 
-#### 1.3.1.0 *(minor)*
+#### 1.3.1.1 *(patch)*
+
+- Drop support for GHC 7
+- Tested with GHC 8.0 - 9.10
+
+### 1.3.1.0 *(minor)*
 
 - Evaluate message before taking lock in simple handler ([#49](https://github.com/haskell-hvr/hslogger/pull/49))
 - Define `Typeable`, `Data`, `Generic` and `NFData` instances for `System.Log.Priority` ([#43](https://github.com/haskell-hvr/hslogger/pull/43))

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,17 +1,10 @@
 branches: master
 
-constraint-set bytestring-0.12
-  ghc: >= 8.2
-  constraints: bytestring ^>= 0.12
-  tests: True
-  run-tests: True
-
-constraint-set containers-0.7
-  ghc: >= 8.2 && < 9.7
-  constraints: containers ^>= 0.7
+constraint-set network-3.2
+  ghc: >= 8.0
+  constraints: network ^>= 3.2.0.0
   tests: True
   run-tests: True
 
 raw-project
-  allow-newer: bytestring
-  allow-newer: containers
+  allow-newer: network

--- a/hslogger.cabal
+++ b/hslogger.cabal
@@ -1,8 +1,7 @@
 cabal-version: 1.12
 build-type: Simple
 name: hslogger
-version: 1.3.1.0
-x-revision: 9
+version: 1.3.1.1
 
 maintainer: https://github.com/haskell-hvr/hslogger
 author: John Goerzen
@@ -36,8 +35,9 @@ extra-source-files:
     testsrc/runtests.hs
 
 tested-with:
-  GHC == 9.8.1
-  GHC == 9.6.3
+  GHC == 9.10.0
+  GHC == 9.8.2
+  GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -79,12 +79,12 @@ library
       , bytestring >= 0.9 && < 0.13
       , containers >= 0.4 && < 0.8
       , deepseq    >= 1.1 && < 1.6
-      , time       >= 1.2 && < 1.13
+      , time       >= 1.2 && < 1.15
       , old-locale >= 1.0 && < 1.1
 
     if flag(network--GT-3_0_0)
       build-depends: network-bsd >= 2.8.1 && <2.9,
-                     network >= 3.0 && <3.2
+                     network >= 3.0 && <3.3
     else
       build-depends: network >= 2.6 && <2.9
 

--- a/src/System/Log/Logger.hs
+++ b/src/System/Log/Logger.hs
@@ -478,7 +478,7 @@ updateGlobalLogger ln func =
     do l <- getLogger ln
        saveGlobalLogger (func l)
 
--- | Allow graceful shutdown. Release all opened files/handlers/etc.
+-- | Allow graceful shutdown. Release all opened files, handlers, etc.
 removeAllHandlers :: IO ()
 removeAllHandlers =
     modifyMVar_ logTree $ \lt -> do


### PR DESCRIPTION
Candidate: https://hackage.haskell.org/package/hslogger-1.3.1.1/candidate