### PR TITLE
v1.3.2.0: Drop flag `network--GT-3_0_0` and support for `network < 3`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250216
+# version: 0.19.20250821
 #
-# REGENDATA ("0.19.20250216",["github","hslogger.cabal"])
+# REGENDATA ("0.19.20250821",["github","hslogger.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,14 +32,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.12.1
+          - compiler: ghc-9.14.0.20250819
             compilerKind: ghc
-            compilerVersion: 9.12.1
+            compilerVersion: 9.14.0.20250819
+            setup-method: ghcup-prerelease
+            allow-failure: false
+          - compiler: ghc-9.12.2
+            compilerKind: ghc
+            compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.1
+          - compiler: ghc-9.10.2
             compilerKind: ghc
-            compilerVersion: 9.10.1
+            compilerVersion: 9.10.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.4
@@ -47,9 +52,9 @@ jobs:
             compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.6
+          - compiler: ghc-9.6.7
             compilerKind: ghc
-            compilerVersion: 9.6.6
+            compilerVersion: 9.6.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -106,15 +111,30 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
@@ -136,7 +156,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -164,6 +184,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -212,10 +244,17 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_hslogger}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package hslogger" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package hslogger" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package hslogger" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           allow-newer: containers
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(hslogger)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -24,8 +24,10 @@ jobs:
         plan:
           - resolver: 'nightly'
           - resolver: 'lts'
-          - ghc: '9.6.6'
-            resolver: 'lts-22.43'
+          - ghc: '9.8.4'
+            resolver: 'lts-23.28'
+          - ghc: '9.6.7'
+            resolver: 'lts-22.44'
           - ghc: '9.4.8'
             resolver: 'lts-21.25'
           - ghc: '9.2.8'
@@ -36,13 +38,8 @@ jobs:
             resolver: 'lts-18.28'
           - ghc: '8.8.4'
             resolver: 'lts-16.31'
-          - ghc: '8.6.5'
-            resolver: 'lts-14.27'
-          - ghc: '8.4.4'
-            resolver: 'lts-12.26'
           # It ends here, because:
-          # LTSs older than 11 don't work with latest hslogger.
-          # Stack dropped support for Cabal 2.0 (GHC 8.2)
+          # LTSs older than 15 do not have network >= 3.
 
         include:
           - os: windows-latest
@@ -64,7 +61,7 @@ jobs:
       STACK: stack --no-terminal --system-ghc --resolver ${{ matrix.plan.resolver }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     # 2024-09-20: On Windows and macOS, Stack is no longer preinstalled
     - uses: haskell-actions/setup@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 1.3.2.0
+
+_2025-08-30, Andreas Abel_
+
+- Drop flag `network--GT-3_0_0` and support for `network < 3`
+- Allow newer `time`
+- Tested with GHC 8.0 - 9.14 alpha1
+
 #### 1.3.1.2
 
 _2025-03-11, Andreas Abel_

--- a/hslogger.cabal
+++ b/hslogger.cabal
@@ -1,7 +1,7 @@
-cabal-version: 1.12
+cabal-version: 1.18
 build-type: Simple
 name: hslogger
-version: 1.3.1.2
+version: 1.3.2.0
 
 maintainer: https://github.com/haskell-hvr/hslogger
 author: John Goerzen
@@ -22,9 +22,11 @@ description:
  or filter messages based on the priority and source.  @hslogger@ also
  has a [Syslog](https://tools.ietf.org/html/rfc5424) handler built in.
 
-extra-source-files:
+extra-doc-files:
     LICENSE
     CHANGELOG.md
+
+extra-source-files:
     contrib/java/build.xml
     contrib/java/hslogger4j.jar
     contrib/java/hslogger4j-plugins.xml
@@ -35,10 +37,11 @@ extra-source-files:
     testsrc/runtests.hs
 
 tested-with:
-  GHC == 9.12.1
-  GHC == 9.10.1
+  GHC == 9.14.1
+  GHC == 9.12.2
+  GHC == 9.10.2
   GHC == 9.8.4
-  GHC == 9.6.6
+  GHC == 9.6.7
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -52,11 +55,6 @@ tested-with:
 source-repository head
   type: git
   location: http://github.com/haskell-hvr/hslogger.git
-
-flag network--GT-3_0_0
-  description: [network](http://hackage.haskell.org/package/network) ≥ 3.0.0
-  default: True
-  manual: False
 
 library
     hs-source-dirs: src
@@ -76,19 +74,14 @@ library
     other-extensions: CPP ExistentialQuantification DeriveDataTypeable
 
     build-depends:
-      -- Lower bounds are chosen from LTS 7.24 (GHC 8.0.1)
-        base       >= 4.9      && < 5
-      , bytestring >= 0.10.8.1 && < 0.13
-      , containers >= 0.5.7.1  && < 1
-      , deepseq    >= 1.4.2.0  && < 1.6
-      , time       >= 1.6.0.1  && < 1.15
-      , old-locale >= 1.0.0.7  && < 1.1
-
-    if flag(network--GT-3_0_0)
-      build-depends: network-bsd >= 2.8.1 && <2.9,
-                     network >= 3.0 && <3.3
-    else
-      build-depends: network >= 2.6.3.1 && <2.9
+      -- Lower bounds are at least the ones from LTS 7.24 (GHC 8.0.1)
+        base         >= 4.9       && < 5
+      , bytestring   >= 0.10.8.1  && < 0.13
+      , containers   >= 0.5.7.1   && < 1
+      , deepseq      >= 1.4.2.0   && < 1.6
+      , time         >= 1.6.0.1   && < 2
+      , network-bsd  >= 2.8.1     && <2.9
+      , network      >= 3.0       && <3.3
 
     if !os(windows)
       Build-Depends: unix >= 2.7.2.0 && < 2.9
@@ -103,5 +96,5 @@ test-suite runtests
     default-language: Haskell2010
     build-depends:
         base
-      , HUnit == 1.3.* || == 1.6.*
+      , HUnit == 1.6.*
       , hslogger

--- a/src/System/Log/Handler/Syslog.hs
+++ b/src/System/Log/Handler/Syslog.hs
@@ -266,6 +266,7 @@ instance LogHandler SyslogHandler where
           sent <- case sock_type sh of
                     S.Datagram -> sendTo (logsocket sh) omsg (address sh)
                     S.Stream   -> send   (logsocket sh) omsg
+                    _ -> undefined
           sendstr (genericDrop sent omsg)
         toSyslogFormat msg' pidPart =
             "<" ++ code ++ ">" ++ identity' ++ pidPart ++ ": " ++ msg' ++ "\0"


### PR DESCRIPTION
Candidate: https://hackage.haskell.org/package/hslogger-1.3.2.0/candidate